### PR TITLE
Bump version in README

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,8 +55,7 @@ lazy val mdoc = project
     fork in run := true,
     buildInfoPackage := "mdoc.internal",
     buildInfoKeys := Seq[BuildInfoKey](
-      version,
-      "stableVersion" -> "0.4.0"
+      version
     ),
     libraryDependencies ++= List(
       "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0",

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -472,6 +472,6 @@ Contributions are welcome!
 
 ````scala mdoc:passthrough
 println("```")
-println(mdoc.internal.cli.Settings.help(mdoc.internal.BuildInfo.stableVersion, 80))
+println(mdoc.internal.cli.Settings.help(mdoc.docs.Docs.stableVersion, 80))
 println("```")
 ````

--- a/mdoc-docs/src/main/scala/mdoc/docs/Docs.scala
+++ b/mdoc-docs/src/main/scala/mdoc/docs/Docs.scala
@@ -8,12 +8,18 @@ import mdoc.internal.BuildInfo
 import mdoc.modifiers.ScastieModifier
 
 object Docs {
+  def stableVersion: String =
+    BuildInfo.version.replaceFirst("\\+.*", "")
   def main(args: Array[String]): Unit = {
     val cwd = PathIO.workingDirectory.toNIO
     val settings = MainSettings()
       .withIn(Paths.get("docs"))
       .withOut(cwd)
-      .withSiteVariables(Map("VERSION" -> BuildInfo.stableVersion))
+      .withSiteVariables(
+        Map(
+          "VERSION" -> stableVersion
+        )
+      )
       .withCleanTarget(false)
       .withReportRelativePaths(true)
       .withStringModifiers(

--- a/readme.md
+++ b/readme.md
@@ -105,7 +105,7 @@ Add the following dependency to your build
 
 ```scala
 // build.sbt
-libraryDependencies += "com.geirsson" % "mdoc" % "0.4.0" cross CrossVersion.full
+libraryDependencies += "com.geirsson" % "mdoc" % "0.4.5" cross CrossVersion.full
 ```
 
 Then write a main function that invokes mdoc as a library
@@ -128,7 +128,7 @@ object Main {
 Consult [--help](#--help) to see what arguments are valid for `withArgs`.
 
 Consult the mdoc source to learn more how to use the library API. Scaladocs are
-available [here](https://www.javadoc.io/doc/com.geirsson/mdoc_2.12.6/0.4.0)
+available [here](https://www.javadoc.io/doc/com.geirsson/mdoc_2.12.6/0.4.5)
 but beware there are limited docstrings for classes and methods. Keep in mind
 that code in the package `mdoc.internal` is subject to binary and source
 breaking changes between any release, including PATCH versions.
@@ -142,7 +142,7 @@ Then run the following command:
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.geirsson/mdoc_2.12.6/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.geirsson/mdoc_2.12.6)
 
 ```
-$ coursier launch com.geirsson:mdoc_2.12.6:0.4.0 -- --site.MY_VERSION 1.0.0
+$ coursier launch com.geirsson:mdoc_2.12.6:0.4.5 -- --site.MY_VERSION 1.0.0
 info: Compiling docs/readme.md
 info:   done => out/readme.md (120 ms)
 ```

--- a/readme.md
+++ b/readme.md
@@ -568,7 +568,7 @@ List(User("John"), User("Susan")).sorted
 
 ### Variable injection
 
-Mdoc renders constants like `0.4.0` in markdown with variables provided at
+Mdoc renders constants like `0.4.5` in markdown with variables provided at
 runtime. This makes it easy to keep documentation up-to-date as new releases are
 published. Variables can be passed from the command-line interface with the
 syntax
@@ -699,7 +699,7 @@ Contributions are welcome!
 ## --help
 
 ```
-Mdoc v0.4.0
+Mdoc v0.4.5
 Usage:   mdoc [<option> ...]
 Example: mdoc --in <path> --out <path> (customize input/output directories)
          mdoc --watch                  (watch for file changes)


### PR DESCRIPTION
`0.4.0` misses the `silent` mode in particular, that is mentioned in the README