### PR TITLE
Gracefully handle position conversion errors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -98,6 +98,8 @@ lazy val unit = project
       List(out)
     },
     libraryDependencies ++= List(
+      "co.fs2" %% "fs2-core" % "0.10.4",
+      "org.scalacheck" %% "scalacheck" % "1.13.5" % Test,
       "org.scalacheck" %% "scalacheck" % "1.13.5" % Test,
       "org.scalatest" %% "scalatest" % "3.2.0-SNAP10" % Test,
       "org.scalameta" %% "testkit" % V.scalameta % Test

--- a/tests/unit/src/test/scala/tests/markdown/FailSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/FailSuite.scala
@@ -120,4 +120,27 @@ class FailSuite extends BaseMarkdownSuite {
     """.stripMargin
   )
 
+  check(
+    "fs2",
+    """
+      |```scala mdoc:fail
+      |fs2.Stream.eval(println("Do not ever do this"))
+      |```
+    """.stripMargin,
+    // NOTE(olafur) https://github.com/olafurpg/mdoc/issues/95#issuecomment-426993507
+    // The error message below does not match the compiler error reported in the REPL.
+    // We should reconsider the architecture for the `fail` modifier.
+    """|```scala
+       |fs2.Stream.eval(println("Do not ever do this"))
+       |// type mismatch;
+       |//  found   : Unit
+       |//  required: ?F[?O]
+       |// Note that implicit conversions are not applicable because they are ambiguous:
+       |//  both method ArrowAssoc in object Predef of type [A](self: A)ArrowAssoc[A]
+       |//  and method Ensuring in object Predef of type [A](self: A)Ensuring[A]
+       |//  are possible conversion functions from Unit to ?F[?O]
+       |```
+    """.stripMargin
+  )
+
 }


### PR DESCRIPTION
Previously, mdoc failed with an exception when converting bogus
positions reported by the compiler. Now we fall back to `Position.None`
instead, which means the message is reported without a caret.

The best long-term solution is probably to reconsider the architecture
for how `fail` modifiers are compiled.  The design in
https://github.com/olafurpg/mdoc/issues/95#issuecomment-426993507 is
both simpler than the current  macro-based design and should also
produce consistent errors with the compiler.