### PR TITLE
Preserve original syntax when rendering instrumented code.

### DIFF
--- a/mdoc/src/main/scala/mdoc/internal/cli/Settings.scala
+++ b/mdoc/src/main/scala/mdoc/internal/cli/Settings.scala
@@ -52,7 +52,7 @@ case class Settings(
     )
     @ExtraName("test")
     check: Boolean = false,
-    @Description("Include additional diagnostics for debuggin potential problems.")
+    @Description("Include additional diagnostics for debugging potential problems.")
     verbose: Boolean = false,
     @Description(
       "Key/value pairs of variables to replace through @VAR@. " +

--- a/mdoc/src/main/scala/mdoc/internal/markdown/Instrumenter.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Instrumenter.scala
@@ -45,14 +45,14 @@ class Instrumenter(sections: List[SectionInput]) {
           sb.print(s"val $fresh = ")
           List(Name(fresh) -> stat.pos)
       }
-      sb.print(stat.syntax)
+      sb.print(stat.pos.text)
       binders.foreach {
         case (name, pos) =>
           printBinder(name.syntax, pos)
       }
 
     case Modifier.Fail =>
-      val literal = Instrumenter.stringLiteral(stat.syntax)
+      val literal = Instrumenter.stringLiteral(stat.pos.text)
       val binder = freshBinder()
       sb.append("val ")
         .append(binder)
@@ -67,10 +67,10 @@ class Instrumenter(sections: List[SectionInput]) {
       sb.append("$doc.crash(")
         .append(position(stat.pos))
         .append(") {\n")
-        .append(stat.syntax)
+        .append(stat.pos.text)
         .append("\n}")
     case Modifier.Str(_, _) =>
-      throw new IllegalArgumentException(stat.syntax)
+      throw new IllegalArgumentException(stat.pos.text)
   }
 }
 object Instrumenter {

--- a/mdoc/src/main/scala/mdoc/internal/markdown/MdocPostProcessor.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/MdocPostProcessor.scala
@@ -62,6 +62,10 @@ class MdocPostProcessor(implicit ctx: Context) extends DocumentPostProcessor {
         }
     }
     val instrumented = Instrumenter.instrument(sectionInputs)
+    if (ctx.settings.verbose) {
+      ctx.reporter.info(s"Instrumented $filename")
+      ctx.reporter.println(instrumented)
+    }
     val rendered = MarkdownCompiler.buildDocument(
       ctx.compiler,
       ctx.reporter,

--- a/mdoc/src/main/scala/mdoc/internal/markdown/Renderer.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Renderer.scala
@@ -43,7 +43,7 @@ object Renderer {
     val out = new ByteArrayOutputStream()
     val ps = new PrintStream(out)
     ps.println("```scala")
-    ps.println(section.source.syntax)
+    ps.println(section.source.pos.text)
     val crashes = for {
       statement <- section.section.statements
       binder <- statement.binders

--- a/readme.md
+++ b/readme.md
@@ -757,7 +757,7 @@ Common options:
     site is up-to-date.
 
   --verbose
-    Include additional diagnostics for debuggin potential problems.
+    Include additional diagnostics for debugging potential problems.
 
   --site Map[String, String] (default: {})
     Key/value pairs of variables to replace through @VAR@. For example, the flag

--- a/tests/unit/src/test/scala/tests/markdown/BaseMarkdownSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/BaseMarkdownSuite.scala
@@ -66,7 +66,9 @@ abstract class BaseMarkdownSuite extends org.scalatest.FunSuite with DiffAsserti
       val input = Input.VirtualFile(name + ".md", original)
       val obtained =
         Markdown.toMarkdown(input, getMarkdownSettings(context), reporter, settings).trimLineEnds
-      val stdout = fansi.Str(myStdout.toString()).plainText
+      val colorOut = myStdout.toString()
+      print(colorOut)
+      val stdout = fansi.Str(colorOut).plainText
       assert(!reporter.hasErrors, stdout)
       assertNoDiffOrPrintExpected(obtained, expected)
     }

--- a/tests/unit/src/test/scala/tests/markdown/DefaultSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/DefaultSuite.scala
@@ -222,4 +222,18 @@ class DefaultSuite extends BaseMarkdownSuite {
     """.stripMargin
   )
 
+  check(
+    "backtick",
+    // see https://github.com/olafurpg/mdoc/issues/97
+    """
+      |```scala mdoc
+      |type `0` = Int
+      |```
+    """.stripMargin,
+    """|```scala
+       |type `0` = Int
+       |```
+       |""".stripMargin
+  )
+
 }


### PR DESCRIPTION
This commit replaces calls to `Tree.syntax` with `Tree.pos.text` which
avoids bugs in the tree pretty printer.

Fixes #97