### PR TITLE
Use fallback port if the provided --port is already bound

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,0 +1,7 @@
+-Xss4m
+-Xms1G
+-Xmx4G
+-XX:ReservedCodeCacheSize=1024m
+-XX:+TieredCompilation
+-XX:+CMSClassUnloadingEnabled
+-Dfile.encoding=UTF-8

--- a/mdoc-docs/src/main/scala/mdoc/docs/EvilplotModifier.scala
+++ b/mdoc-docs/src/main/scala/mdoc/docs/EvilplotModifier.scala
@@ -12,10 +12,9 @@ class EvilplotModifier extends PostModifier {
     ctx.lastValue match {
       case d: Drawable =>
         Files.createDirectories(out.toNIO.getParent)
-        if (out.isFile) {
-          Files.delete(out.toNIO)
+        if (!out.isFile) {
+          d.write(out.toFile)
         }
-        d.write(out.toFile)
         s"![](${out.toNIO.getFileName})"
       case _ =>
         val (pos, obtained) = ctx.variables.lastOption match {

--- a/mdoc/src/main/scala/mdoc/internal/cli/MainOps.scala
+++ b/mdoc/src/main/scala/mdoc/internal/cli/MainOps.scala
@@ -36,7 +36,7 @@ final class MainOps(
       val livereload = UndertowLiveReload(
         settings.out.toNIO,
         host = settings.host,
-        port = settings.port,
+        preferredPort = settings.port,
         reporter = reporter
       )
       livereload.start()

--- a/mdoc/src/main/scala/mdoc/internal/cli/Settings.scala
+++ b/mdoc/src/main/scala/mdoc/internal/cli/Settings.scala
@@ -77,7 +77,10 @@ case class Settings(
     @Section("LiveReload options")
     @Description("Don't start a LiveReload server")
     noLivereload: Boolean = false,
-    @Description("Which port the LiveReload server should listen to")
+    @Description(
+      "Which port the LiveReload server should listen to. " +
+        "If the port is not free, another free port close to this number is used."
+    )
     port: Int = 4000,
     @Description("Which hostname the LiveReload server should listen to")
     host: String = "localhost",

--- a/readme.md
+++ b/readme.md
@@ -410,10 +410,9 @@ class EvilplotModifier extends PostModifier {
     ctx.lastValue match {
       case d: Drawable =>
         Files.createDirectories(out.toNIO.getParent)
-        if (out.isFile) {
-          Files.delete(out.toNIO)
+        if (!out.isFile) {
+          d.write(out.toFile)
         }
-        d.write(out.toFile)
         s"![](${out.toNIO.getFileName})"
       case _ =>
         val (pos, obtained) = ctx.variables.lastOption match {
@@ -959,7 +958,8 @@ LiveReload options:
     Don't start a LiveReload server
 
   --port Int (default: 4000)
-    Which port the LiveReload server should listen to
+    Which port the LiveReload server should listen to. If the port is not free,
+    another free port close to this number is used.
 
   --host String (default: "localhost")
     Which hostname the LiveReload server should listen to


### PR DESCRIPTION
This makes it easy to run parallel mdoc --watch instances.