### PR TITLE
Tone down noise in reporter output

### DIFF
--- a/mdoc/src/main/scala/mdoc/Reporter.scala
+++ b/mdoc/src/main/scala/mdoc/Reporter.scala
@@ -16,5 +16,7 @@ trait Reporter {
 
   private[mdoc] def hasWarnings: Boolean
   private[mdoc] def hasErrors: Boolean
+  private[mdoc] def warningCount: Int
+  private[mdoc] def errorCount: Int
   private[mdoc] def reset(): Unit
 }

--- a/mdoc/src/main/scala/mdoc/internal/cli/Messages.scala
+++ b/mdoc/src/main/scala/mdoc/internal/cli/Messages.scala
@@ -1,0 +1,8 @@
+package mdoc.internal.cli
+
+object Messages {
+  def count(what: String, number: Int): String = {
+    if (number == 1) s"$number $what"
+    else s"$number ${what}s"
+  }
+}

--- a/mdoc/src/main/scala/mdoc/internal/cli/Timer.scala
+++ b/mdoc/src/main/scala/mdoc/internal/cli/Timer.scala
@@ -1,0 +1,43 @@
+package mdoc.internal.cli
+
+import java.text.DecimalFormat
+import java.util.concurrent.TimeUnit
+
+class Timer() {
+  val startNanos: Long = System.nanoTime()
+  def elapsedNanos: Long = {
+    val now = System.nanoTime()
+    now - startNanos
+  }
+  def elapsedMillis: Long = {
+    TimeUnit.NANOSECONDS.toMillis(elapsedNanos)
+  }
+  def elapsedSeconds: Long = {
+    TimeUnit.NANOSECONDS.toSeconds(elapsedNanos)
+  }
+  override def toString: String = {
+    Timer.readableNanos(elapsedNanos)
+  }
+}
+
+object Timer {
+  def readableNanos(nanos: Long): String = {
+    val seconds = TimeUnit.NANOSECONDS.toSeconds(nanos)
+    if (seconds > 20) readableSeconds(seconds)
+    else {
+      val ms = TimeUnit.NANOSECONDS.toMillis(nanos).toDouble
+      val partialSeconds = ms / 1000
+      new DecimalFormat("#.##s").format(partialSeconds)
+    }
+  }
+  def readableSeconds(n: Long): String = {
+    val minutes = n / 60
+    val seconds = n % 60
+    if (minutes > 0) {
+      if (seconds == 0) s"${minutes}m"
+      else s"${minutes}m${seconds}s"
+    } else {
+      s"${seconds}s"
+    }
+  }
+}

--- a/mdoc/src/main/scala/mdoc/internal/io/ConsoleReporter.scala
+++ b/mdoc/src/main/scala/mdoc/internal/io/ConsoleReporter.scala
@@ -15,6 +15,9 @@ class ConsoleReporter(ps: PrintStream) extends Reporter {
 
   private var myWarnings = 0
   private var myErrors = 0
+
+  override def warningCount: Int = myWarnings
+  override def errorCount: Int = myErrors
   def hasWarnings: Boolean = myWarnings > 0
   def hasErrors: Boolean = myErrors > 0
   def reset(): Unit = {

--- a/mdoc/src/main/scala/mdoc/internal/io/DelegatingReporter.scala
+++ b/mdoc/src/main/scala/mdoc/internal/io/DelegatingReporter.scala
@@ -23,6 +23,11 @@ class DelegatingReporter(underlying: List[Reporter]) extends Reporter {
     underlying.foreach(_.print(msg))
   override def println(msg: String): Unit =
     underlying.foreach(_.println(msg))
+
+  override def warningCount: Int =
+    underlying.foldLeft(0)(_ + _.warningCount)
+  override def errorCount: Int =
+    underlying.foldLeft(0)(_ + _.errorCount)
   override private[mdoc] def hasWarnings: Boolean =
     underlying.exists(_.hasWarnings)
   override private[mdoc] def hasErrors: Boolean =

--- a/mdoc/src/main/scala/mdoc/internal/io/IO.scala
+++ b/mdoc/src/main/scala/mdoc/internal/io/IO.scala
@@ -34,6 +34,12 @@ object IO {
       }
     )
   }
+  def inputFiles(settings: Settings): List[InputFile] = {
+    val buf = List.newBuilder[InputFile]
+    foreachInputFile(settings)(buf += _)
+    buf.result()
+  }
+
   def foreachInputFile(settings: Settings)(fn: InputFile => Unit): Unit = {
     implicit val cwd = settings.cwd
     val root = settings.in.toNIO

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M6")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M9")

--- a/tests/unit/src/test/scala/tests/cli/CliSuite.scala
+++ b/tests/unit/src/test/scala/tests/cli/CliSuite.scala
@@ -132,14 +132,20 @@ class CliSuite extends BaseCliSuite {
       |```
       |/before-index.md
       |# Header
+      |[Head](#head)
     """.stripMargin,
     """
       |/before-index.md
       |# Header
+      |
+      |[Head](#head)
     """.stripMargin, // did not generate index.md
     expectedExitCode = 1,
     onStdout = { out =>
+      assert(out.contains("Compiling 2 files to"))
       assert(out.contains("Invalid mode 'foobar'"))
+      assert(out.contains("Compiled in"))
+      assert(out.contains("(1 error, 1 warning)"))
     }
   )
 


### PR DESCRIPTION
This commit removes the "Compiling $FILE" and " done => $FILE"
logs polishes the default output to show summaries instead.

```
info: Compiling 40 files to /Users/olafurpg/dev/metals/website/target/docs
warning: editors/overview.md:134:17: warning: Unknown link 'editors/new-editor.html', did you mean 'editors/new-editor.md'?
extensions, see [integrating a new editor](new-editor.html).
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
warning: contributors/getting-started.md:88:19: warning: Unknown link 'editors/vim.html'.
First, follow the [`vim` installation instruction](../editors/vim.html).
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
warning: build-tools/overview.md:47:1: warning: Unknown link 'build-tools/new-build-tool.html', did you mean 'build-tools/new-build-tool.md'?
[guide to integrate new build tools](new-build-tool.html).
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
info: Compiled in 0.52s (0 errors, 3 warnings)
```

This change makes it easier to notice errors because they are no longer
lost in 40 lines of "info: Compiling $FILE". The old logs are still available under --verbose.

Thanks @alexarchambault for the idea!