### PR TITLE
Add mdoc:reset modifier to clear scope.

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -28,26 +28,27 @@ Table of contents:
 <!-- TOC depthFrom:2 -->
 
 - [Quickstart](#quickstart)
-  - [Library](#library)
-  - [sbt](#sbt)
-  - [Command-line](#command-line)
+    - [Library](#library)
+    - [sbt](#sbt)
+    - [Command-line](#command-line)
 - [Modifiers](#modifiers)
-  - [Default](#default)
-  - [Silent](#silent)
-  - [Fail](#fail)
-  - [Crash](#crash)
-  - [Passthrough](#passthrough)
-  - [Invisible](#invisible)
-  - [PostModifier](#postmodifier)
-  - [StringModifier](#stringmodifier)
-  - [Scastie](#scastie)
+    - [Default](#default)
+    - [Silent](#silent)
+    - [Fail](#fail)
+    - [Crash](#crash)
+    - [Passthrough](#passthrough)
+    - [Invisible](#invisible)
+    - [Reset](#reset)
+    - [PostModifier](#postmodifier)
+    - [StringModifier](#stringmodifier)
+    - [Scastie](#scastie)
 - [Key features](#key-features)
-  - [Performance](#performance)
-  - [Good error messages](#good-error-messages)
-  - [Link hygiene](#link-hygiene)
-  - [Script semantics](#script-semantics)
-  - [Variable injection](#variable-injection)
-  - [Extensible](#extensible)
+    - [Performance](#performance)
+    - [Good error messages](#good-error-messages)
+    - [Link hygiene](#link-hygiene)
+    - [Script semantics](#script-semantics)
+    - [Variable injection](#variable-injection)
+    - [Extensible](#extensible)
 - [Team](#team)
 - [--help](#--help)
 
@@ -282,6 +283,26 @@ println("I am invisible")
 ```
 More prose.
 ````
+
+### Reset
+
+The `reset` modifier starts a new scope where previous statements in the document are no longer available.
+This can be helpful to clear existing imports or implicits in scope.
+
+````scala mdoc:mdoc
+```scala mdoc
+implicit val x: Int = 41
+```
+
+```scala mdoc:reset
+implicit val y: Int = 42
+implicitly[Int] // x is no longer in scope
+```
+```scala mdoc:fail
+println(x)
+```
+````
+
 
 ### PostModifier
 

--- a/mdoc/src/main/scala/mdoc/internal/markdown/MdocPostProcessor.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/MdocPostProcessor.scala
@@ -119,7 +119,7 @@ class MdocPostProcessor(implicit ctx: Context) extends DocumentPostProcessor {
             )
             val postRender = modifier.process(postCtx)
             replaceNodeWithText(doc, block, postRender)
-          case Modifier.Default | Modifier.Fail =>
+          case Modifier.Default | Modifier.Reset | Modifier.Fail =>
             block.setContent(List[BasedSequence](CharSubSequence.of(defaultRender)).asJava)
           case Modifier.Passthrough =>
             replaceNodeWithText(doc, block, section.out)

--- a/mdoc/src/main/scala/mdoc/internal/markdown/Modifier.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Modifier.scala
@@ -23,7 +23,15 @@ sealed trait Modifier {
   def isSilent: Boolean = this == Silent
 }
 object Modifier {
-  def all: List[Modifier] = List(Default, Passthrough, Invisible, Fail, Crash, Silent)
+  def all: List[Modifier] = List(
+    Default,
+    Passthrough,
+    Invisible,
+    Reset,
+    Fail,
+    Crash,
+    Silent
+  )
   def apply(string: String): Option[Modifier] =
     all.find(_.toString.equalsIgnoreCase(string))
 
@@ -44,6 +52,9 @@ object Modifier {
 
   /** Do no render anything. */
   case object Invisible extends Modifier
+
+  /** Start from scratch and ignore all declarations in this document. */
+  case object Reset extends Modifier
 
   /** Render this code fence according to this string modifier */
   case class Str(mod: StringModifier, info: String) extends Modifier

--- a/mdoc/src/main/scala/mdoc/internal/markdown/Renderer.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Renderer.scala
@@ -139,7 +139,7 @@ object Renderer {
                         s"Obtained $obtained"
                     )
                 }
-              case Modifier.Default | Modifier.Passthrough | Modifier.Post(_, _) =>
+              case Modifier.Default | Modifier.Passthrough | Modifier.Reset | Modifier.Post(_, _) =>
                 val pos = binder.pos.toMeta(section)
                 val variable = new mdoc.Variable(
                   binder.name,

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,7 @@ Table of contents:
   - [Crash](#crash)
   - [Passthrough](#passthrough)
   - [Invisible](#invisible)
+  - [Reset](#reset)
   - [PostModifier](#postmodifier)
   - [StringModifier](#stringmodifier)
   - [Scastie](#scastie)
@@ -377,6 +378,52 @@ This is prose.
 
 More prose.
 ````
+
+### Reset
+
+The `reset` modifier starts a new scope where previous statements in the document are no longer available.
+This can be helpful to clear existing imports or implicits in scope.
+
+
+Before:
+
+````
+```scala mdoc
+implicit val x: Int = 41
+```
+
+```scala mdoc:reset
+implicit val y: Int = 42
+implicitly[Int] // x is no longer in scope
+```
+```scala mdoc:fail
+println(x)
+```
+````
+
+After:
+
+````
+```scala
+implicit val x: Int = 41
+// x: Int = 41
+```
+
+```scala
+implicit val y: Int = 42
+// y: Int = 42
+implicitly[Int] // x is no longer in scope
+// res0: Int = 42
+```
+
+```scala
+println(x)
+// not found: value x
+// println(x)
+//         ^
+```
+````
+
 
 ### PostModifier
 

--- a/tests/unit/src/test/scala/tests/markdown/ResetSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/ResetSuite.scala
@@ -1,0 +1,42 @@
+package tests.markdown
+
+class ResetSuite extends BaseMarkdownSuite {
+
+  check(
+    "basic",
+    """
+      |```scala mdoc
+      |implicit val x: Int = 42
+      |```
+      |
+      |```scala mdoc:reset
+      |implicit val y: Int = 42
+      |println(implicitly[Int])
+      |```
+      |
+      |```scala mdoc:fail
+      |println(x)
+      |```
+    """.stripMargin,
+    """|```scala
+       |implicit val x: Int = 42
+       |// x: Int = 42
+       |```
+       |
+       |```scala
+       |implicit val y: Int = 42
+       |// y: Int = 42
+       |println(implicitly[Int])
+       |// 42
+       |```
+       |
+       |```scala
+       |println(x)
+       |// not found: value x
+       |// println(x)
+       |//         ^
+       |```
+    """.stripMargin
+  )
+
+}


### PR DESCRIPTION
This modifier exists in tut and can be helpful in large documents when
we want to start from scratch.