### PR TITLE
Change mdoc:fail encoding to use proper compiler

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,6 @@ name := "mdocRoot"
 skip in publish := true
 val V = new {
   val scalameta = "4.1.0"
-  val scalafix = "0.9.1"
 }
 
 lazy val runtime = project
@@ -70,7 +69,6 @@ lazy val mdoc = project
       "com.lihaoyi" %% "fansi" % "0.2.5",
       "io.methvin" % "directory-watcher" % "0.8.0",
       "me.xdrop" % "fuzzywuzzy" % "1.1.10", // for link hygiene "did you mean?"
-      "ch.epfl.scala" %% "scalafix-core" % V.scalafix,
       // live reload
       "io.undertow" % "undertow-core" % "2.0.13.Final",
       "org.jboss.xnio" % "xnio-nio" % "3.6.5.Final",

--- a/mdoc/src/main/scala/mdoc/internal/cli/MainOps.scala
+++ b/mdoc/src/main/scala/mdoc/internal/cli/MainOps.scala
@@ -15,13 +15,13 @@ import mdoc.internal.livereload.UndertowLiveReload
 import mdoc.internal.markdown.DocumentLinks
 import mdoc.internal.markdown.LinkHygiene
 import mdoc.internal.markdown.Markdown
+import mdoc.internal.pos.DiffUtils
 import metaconfig.Configured
 import scala.meta.Input
 import scala.meta.internal.io.FileIO
 import scala.meta.internal.io.PathIO
 import scala.meta.io.AbsolutePath
 import scala.util.control.NonFatal
-import scalafix.internal.diff.DiffUtils
 
 final class MainOps(
     settings: Settings,

--- a/mdoc/src/main/scala/mdoc/internal/io/ConsoleReporter.scala
+++ b/mdoc/src/main/scala/mdoc/internal/io/ConsoleReporter.scala
@@ -1,17 +1,25 @@
 package mdoc.internal.io
 
+import fansi.Attrs
 import fansi.Color._
 import java.io.PrintStream
 import scala.meta.Position
-import scalafix.internal.util.PositionSyntax._
 import mdoc.Reporter
 import mdoc.internal.pos.PositionSyntax._
 
-class ConsoleReporter(ps: PrintStream) extends Reporter {
+class ConsoleReporter(
+    ps: PrintStream,
+    blue: Attrs = Blue,
+    yellow: Attrs = Yellow,
+    red: Attrs = Red
+) extends Reporter {
 
-  private val myInfo = Blue("info")
-  private val myWarning = Yellow("warning")
-  private val myError = Red("error")
+  def formatMessage(pos: Position, severity: String, message: String): String =
+    pos.formatMessage(severity, message)
+
+  private val myInfo = blue("info")
+  private val myWarning = yellow("warning")
+  private val myError = red("error")
 
   private var myWarnings = 0
   private var myErrors = 0
@@ -34,20 +42,20 @@ class ConsoleReporter(ps: PrintStream) extends Reporter {
     throwable.printStackTrace(ps)
   }
   def error(pos: Position, msg: String): Unit = {
-    error(pos.toUnslicedPosition.formatMessage("error", msg))
+    error(formatMessage(pos.toUnslicedPosition, "error", msg))
   }
   def error(msg: String): Unit = {
     myErrors += 1
     ps.println(myError ++ s": $msg")
   }
   def info(pos: Position, msg: String): Unit = {
-    info(pos.toUnslicedPosition.formatMessage("info", msg))
+    info(formatMessage(pos.toUnslicedPosition, "info", msg))
   }
   def info(msg: String): Unit = {
     ps.println(myInfo ++ s": $msg")
   }
   def warning(pos: Position, msg: String): Unit = {
-    warning(pos.toUnslicedPosition.formatMessage("warning", msg))
+    warning(formatMessage(pos.toUnslicedPosition, "warning", msg))
   }
   def warning(msg: String): Unit = {
     myWarnings += 1

--- a/mdoc/src/main/scala/mdoc/internal/markdown/FailInstrumenter.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/FailInstrumenter.scala
@@ -1,0 +1,33 @@
+package mdoc.internal.markdown
+
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+
+final class FailInstrumenter(sections: List[SectionInput], i: Int) {
+  private val out = new ByteArrayOutputStream()
+  private val sb = new PrintStream(out)
+  private val gensym = new Gensym()
+  def instrument(): String = {
+    printAsScript()
+    out.toString
+  }
+  private def printAsScript(): Unit = {
+    sb.println("package repl")
+    sb.println("class Session {")
+    sb.println("  def app() = {")
+    sections.zipWithIndex.foreach {
+      case (section, j) =>
+        if (j > i) ()
+        else {
+          if (section.mod == Modifier.Reset) {
+            val nextApp = gensym.fresh("app", "()")
+            sb.print(s"this.$nextApp\n}\ndef $nextApp: Unit = {\n")
+          }
+          if (j == i || section.mod != Modifier.Fail) {
+            sb.println(section.input.text)
+          }
+        }
+    }
+    sb.println("\n  }\n}")
+  }
+}

--- a/mdoc/src/main/scala/mdoc/internal/markdown/Gensym.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Gensym.scala
@@ -1,0 +1,10 @@
+package mdoc.internal.markdown
+
+class Gensym() {
+  private var counter = 0
+  def fresh(prefix: String, suffix: String = ""): String = {
+    val name = s"$prefix$counter$suffix"
+    counter += 1
+    name
+  }
+}

--- a/mdoc/src/main/scala/mdoc/internal/markdown/MdocPostProcessor.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/MdocPostProcessor.scala
@@ -86,7 +86,8 @@ class MdocPostProcessor(implicit ctx: Context) extends DocumentPostProcessor {
           rendered,
           section,
           ctx.reporter,
-          ctx.settings.variablePrinter
+          ctx.settings.variablePrinter,
+          ctx.compiler
         )
         mod match {
           case Modifier.Silent =>

--- a/mdoc/src/main/scala/mdoc/internal/pos/DiffUtils.scala
+++ b/mdoc/src/main/scala/mdoc/internal/pos/DiffUtils.scala
@@ -1,0 +1,24 @@
+package mdoc.internal.pos
+
+import difflib.{DiffUtils => DU}
+import scala.collection.JavaConverters._
+
+object DiffUtils {
+  def unifiedDiff(
+      originalFileName: String,
+      revisedFileName: String,
+      originalLines: List[String],
+      revisedLines: List[String],
+      contextSize: Int
+  ): String = {
+    val patch = DU.diff(originalLines.asJava, revisedLines.asJava)
+    val diff = DU.generateUnifiedDiff(
+      originalFileName,
+      revisedFileName,
+      originalLines.asJava,
+      patch,
+      contextSize
+    )
+    diff.asScala.mkString("\n")
+  }
+}

--- a/mdoc/src/main/scala/mdoc/internal/pos/PositionSyntax.scala
+++ b/mdoc/src/main/scala/mdoc/internal/pos/PositionSyntax.scala
@@ -5,7 +5,6 @@ import scala.meta.Input
 import scala.meta.Position
 import scala.meta.io.AbsolutePath
 import scala.meta.io.RelativePath
-import scalafix.internal.util.PositionSyntax._
 import mdoc.document.RangePosition
 import mdoc.internal.cli.Settings
 import mdoc.internal.markdown.EvaluatedSection
@@ -84,4 +83,75 @@ object PositionSyntax {
       }
     }
   }
+
+  def formatMessage(
+      pos: Position,
+      severity: String,
+      message: String,
+      includePath: Boolean = true
+  ): String =
+    pos match {
+      case Position.None =>
+        s"$severity: $message"
+      case _ =>
+        new java.lang.StringBuilder()
+          .append(if (includePath) pos.lineInput else "")
+          .append(if (!includePath || severity.isEmpty) "" else " ")
+          .append(severity)
+          .append(
+            if (message.isEmpty) ""
+            else if (severity.isEmpty) " "
+            else if (message.startsWith("\n")) ":"
+            else ": "
+          )
+          .append(message)
+          .append("\n")
+          .append(pos.lineContent)
+          .append("\n")
+          .append(pos.lineCaret)
+          .toString
+    }
+
+  implicit class XtensionPositionsScalafix(private val pos: Position) extends AnyVal {
+
+    def contains(other: Position): Boolean = {
+      pos.start <= other.start &&
+      pos.end >= other.end
+    }
+
+    def formatMessage(severity: String, message: String): String =
+      PositionSyntax.formatMessage(pos, severity, message)
+
+    /** Returns a formatted string of this position including filename/line/caret. */
+    def lineInput: String =
+      s"${pos.input.syntax}:${pos.startLine + 1}:${pos.startColumn + 1}:"
+
+    def rangeNumber: String =
+      s"${pos.startLine + 1}:${pos.startColumn + 1}..${pos.endLine + 1}:${pos.endColumn + 1}"
+
+    def lineCaret: String = pos match {
+      case Position.None =>
+        ""
+      case _ =>
+        val caret =
+          if (pos.start == pos.end) "^"
+          else if (pos.startLine == pos.endLine) "^" * (pos.end - pos.start)
+          else "^"
+        (" " * pos.startColumn) + caret
+    }
+
+    def lineContent: String = pos match {
+      case Position.None => ""
+      case range: Position.Range =>
+        val pos = Position.Range(
+          range.input,
+          range.startLine,
+          0,
+          range.startLine,
+          Int.MaxValue
+        )
+        pos.text
+    }
+  }
+
 }

--- a/mdoc/src/main/scala/mdoc/internal/pos/TokenEditDistance.scala
+++ b/mdoc/src/main/scala/mdoc/internal/pos/TokenEditDistance.scala
@@ -116,7 +116,7 @@ object TokenEditDistance {
     }
     val deltas = {
       import scala.collection.JavaConverters._
-      DiffUtils
+      difflib.DiffUtils
         .diff(original.asJava, revised.asJava, TokenEqualizer)
         .getDeltas
         .iterator()

--- a/readme.md
+++ b/readme.md
@@ -274,11 +274,11 @@ After:
 ````
 ```scala
 val x: Int = ""
-// type mismatch;
+// error: type mismatch;
 //  found   : String("")
 //  required: Int
 // val x: Int = ""
-//              ^
+//              ^^
 ```
 ````
 
@@ -413,12 +413,12 @@ implicit val x: Int = 41
 implicit val y: Int = 42
 // y: Int = 42
 implicitly[Int] // x is no longer in scope
-// res0: Int = 42
+// res1: Int = 42
 ```
 
 ```scala
 println(x)
-// not found: value x
+// error: not found: value x
 // println(x)
 //         ^
 ```

--- a/runtime/src/main/scala/mdoc/internal/document/Macros.scala
+++ b/runtime/src/main/scala/mdoc/internal/document/Macros.scala
@@ -9,7 +9,13 @@ import mdoc.document.CompileResult._
 import mdoc.document.RangePosition
 
 object Macros {
-
+  case class Delay(
+      code: String,
+      startLine: Int,
+      startColumn: Int,
+      endLine: Int,
+      endColumn: Int
+  )
   def fail(
       code: String,
       startLine: Int,

--- a/tests/unit/src/test/scala/tests/markdown/FailSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/FailSuite.scala
@@ -11,15 +11,14 @@ class FailSuite extends BaseMarkdownSuite {
       |val x: Int = "String"
       |```
     """.stripMargin,
-    """
-      |```scala
-      |val x: Int = "String"
-      |// type mismatch;
-      |//  found   : String("String")
-      |//  required: Int
-      |// val x: Int = "String"
-      |//              ^
-      |```
+    """|```scala
+       |val x: Int = "String"
+       |// error: type mismatch;
+       |//  found   : String("String")
+       |//  required: Int
+       |// val x: Int = "String"
+       |//              ^^^^^^^^
+       |```
     """.stripMargin
   )
 
@@ -37,7 +36,7 @@ class FailSuite extends BaseMarkdownSuite {
       |val y: Int = '''Triplequote
       |newlines
       |'''
-      |// type mismatch;
+      |// error: type mismatch;
       |//  found   : String("Triplequote\nnewlines\n")
       |//  required: Int
       |// val y: Int = '''Triplequote
@@ -103,20 +102,19 @@ class FailSuite extends BaseMarkdownSuite {
       |val x: Int = "String"
       |```
     """.stripMargin,
-    """
-      |```scala
-      |println(42)
-      |// 42
-      |```
-      |
-      |```scala
-      |val x: Int = "String"
-      |// type mismatch;
-      |//  found   : String("String")
-      |//  required: Int
-      |// val x: Int = "String"
-      |//              ^
-      |```
+    """|```scala
+       |println(42)
+       |// 42
+       |```
+       |
+       |```scala
+       |val x: Int = "String"
+       |// error: type mismatch;
+       |//  found   : String("String")
+       |//  required: Int
+       |// val x: Int = "String"
+       |//              ^^^^^^^^
+       |```
     """.stripMargin
   )
 
@@ -132,13 +130,76 @@ class FailSuite extends BaseMarkdownSuite {
     // We should reconsider the architecture for the `fail` modifier.
     """|```scala
        |fs2.Stream.eval(println("Do not ever do this"))
-       |// type mismatch;
+       |// error: no type parameters for method eval: (fo: F[O])fs2.Stream[F,O] exist so that it can be applied to arguments (Unit)
+       |//  --- because ---
+       |// argument expression's type is not compatible with formal parameter type;
        |//  found   : Unit
        |//  required: ?F[?O]
-       |// Note that implicit conversions are not applicable because they are ambiguous:
-       |//  both method ArrowAssoc in object Predef of type [A](self: A)ArrowAssoc[A]
-       |//  and method Ensuring in object Predef of type [A](self: A)Ensuring[A]
-       |//  are possible conversion functions from Unit to ?F[?O]
+       |// fs2.Stream.eval(println("Do not ever do this"))
+       |// ^^^^^^^^^^^^^^^
+       |// error: type mismatch;
+       |//  found   : Unit
+       |//  required: F[O]
+       |// fs2.Stream.eval(println("Do not ever do this"))
+       |//                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       |```
+    """.stripMargin
+  )
+
+  check(
+    "double",
+    """
+      |```scala mdoc:fail
+      |println(a)
+      |println(b)
+      |```
+    """.stripMargin,
+    """|```scala
+       |println(a)
+       |println(b)
+       |// error: not found: value a
+       |// println(a)
+       |//         ^
+       |// error: not found: value b
+       |// println(b)
+       |//         ^
+       |```
+    """.stripMargin
+  )
+
+  check(
+    "edit",
+    """
+      |```scala mdoc:fail
+      |val x = 1
+      |println(a)
+      |println(b)
+      |```
+      |
+      |```scala mdoc:fail
+      |val x = 1
+      |println(c)
+      |println(d)
+      |```
+    """.stripMargin,
+    """|```scala
+       |val x = 1
+       |println(a)
+       |println(b)
+       |// error: not found: value a
+       |// error: not found: value b
+       |```
+       |
+       |```scala
+       |val x = 1
+       |println(c)
+       |println(d)
+       |// error: not found: value c
+       |// println(c)
+       |//         ^
+       |// error: not found: value d
+       |// println(d)
+       |//         ^
        |```
     """.stripMargin
   )

--- a/tests/unit/src/test/scala/tests/markdown/ResetSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/ResetSuite.scala
@@ -32,7 +32,7 @@ class ResetSuite extends BaseMarkdownSuite {
        |
        |```scala
        |println(x)
-       |// not found: value x
+       |// error: not found: value x
        |// println(x)
        |//         ^
        |```


### PR DESCRIPTION
Fixes #95.

Previously, we used a macro to get compile errors for mdoc:fail.
However, this resulted in wrong compile error messages in rare cases.
Now, we produce  a full compilation unit for each mdoc:fail section
and compile as a regular source file.

A benefit of this new approach is that we report pretty range position
error messages instead of offset positions.

This change required customizing position formatting so I inlined the
Scalafix utils we were using and removed the Scalafix dependency.