### PR TITLE
Enable overloaded and mutually recursive methods.

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -533,13 +533,13 @@ unknown link.
 
 ### Program semantics
 
-mdoc interprets code fences as normal Scala programs instead of as if they're
-evaluated in the REPL. This behavior is different from tut that interprets
-statements as if they were typed in a REPL session. Using "script semantics"
-instead of "repl semantics" has both benefits and downsides.
+mdoc interprets code fences as normal Scala programs instead of using the REPL.
+This behavior is different from tut that interprets statements as if they were
+typed in a REPL session. Using "program semantics" instead of "repl semantics"
+has benefits and downsides.
 
 **Downside**: It's not possible to bind the same variable twice, for example the
-code below input fails compilation with mdoc but compiles successfully with tut
+code below fails compilation with mdoc but compiles successfully with tut
 
 ````
 ```scala mdoc
@@ -548,10 +548,10 @@ val x = 1
 ```
 ````
 
-**Upside**: Code examples can be copy-pasted into normal Scala programs and
-compile.
+**Upside**: Code examples from the documentation can be copy-pasted into normal
+Scala programs and compile.
 
-**Upside**: Companion objects Just Work™️
+**Upside**: Companion objects work as expected.
 
 ````scala mdoc:mdoc
 ```scala mdoc
@@ -559,15 +559,46 @@ case class User(name: String)
 object User {
   implicit val ordering: Ordering[User] = Ordering.by(_.name)
 }
-List(User("John"), User("Susan")).sorted
+List(User("Susan"), User("John")).sorted
 ```
 ````
 
+**Upside**: Overloaded methods work as expected.
+
+````scala mdoc:mdoc
+```scala mdoc
+def add(a: Int, b: Int): Int = a + b
+def add(a: Int): Int = add(a, 1)
+add(3)
+```
+````
+
+**Upside**: Mutually recursive methods work as expected.
+
+````scala mdoc:mdoc
+```scala mdoc
+def isEven(n: Int): Boolean = n == 0 || !isOdd(n - 1)
+def isOdd(n: Int): Boolean  = n == 1 || !isEven(n - 1)
+isEven(8)
+```
+````
+
+**Upside**: Compiler options like `-Ywarn-unused` don't report spurious errors like they do in the REPL.
+```scala
+$ scala -Ywarn-unused
+scala> import scala.concurrent.Future
+<console>:11: warning: Unused import
+       import scala.concurrent.Future
+                               ^
+scala> Future.successful(1)
+res0: scala.concurrent.Future[Int] = Future(Success(1))
+```
+
 ### Variable injection
 
-mdoc renders variables like `@@VERSION@` into `@VERSION@`. This makes it easy to keep documentation
-up-to-date as new releases are published. Variables can be passed from the
-command-line interface with the syntax
+mdoc renders variables like `@@VERSION@` into `@VERSION@`. This makes it easy to
+keep documentation up-to-date as new releases are published. Variables can be
+passed from the command-line interface with the syntax
 
 ```
 mdoc --site.VERSION 1.0.0 --site.SCALA_VERSION @SCALA_VERSION@

--- a/mdoc/src/main/scala/mdoc/internal/markdown/FailInstrumenter.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/FailInstrumenter.scala
@@ -14,14 +14,14 @@ final class FailInstrumenter(sections: List[SectionInput], i: Int) {
   private def printAsScript(): Unit = {
     sb.println("package repl")
     sb.println("class Session {")
-    sb.println("  def app() = {")
+    sb.println("  class App() {")
     sections.zipWithIndex.foreach {
       case (section, j) =>
         if (j > i) ()
         else {
           if (section.mod == Modifier.Reset) {
-            val nextApp = gensym.fresh("app", "()")
-            sb.print(s"this.$nextApp\n}\ndef $nextApp: Unit = {\n")
+            val nextApp = gensym.fresh("App", "()")
+            sb.print(s"new $nextApp\n}\nclass $nextApp {\n")
           }
           if (j == i || section.mod != Modifier.Fail) {
             sb.println(section.input.text)

--- a/mdoc/src/main/scala/mdoc/internal/markdown/FilterStoreReporter.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/FilterStoreReporter.scala
@@ -1,0 +1,25 @@
+package mdoc.internal.markdown
+
+import scala.collection.mutable
+import scala.tools.nsc.Settings
+import scala.tools.nsc.reporters.AbstractReporter
+import scala.reflect.internal.util.Position
+
+/** Same as nsc StoreReporter except it extends AbstractReporter.
+  *
+  * The AbstractReporter does filtering based on position to avoid duplicate diagnostics.
+  */
+class FilterStoreReporter(val settings: Settings) extends AbstractReporter {
+  case class Info(pos: Position, msg: String, severity: Severity) {
+    override def toString() = s"pos: $pos $msg $severity"
+  }
+  val infos = new mutable.LinkedHashSet[Info]
+  override def display(pos: Position, msg: String, severity: Severity): Unit = {
+    infos += Info(pos, msg, severity)
+  }
+  override def reset(): Unit = {
+    super.reset()
+    infos.clear()
+  }
+  override def displayPrompt(): Unit = ()
+}

--- a/mdoc/src/main/scala/mdoc/internal/markdown/Instrumenter.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Instrumenter.scala
@@ -19,8 +19,8 @@ class Instrumenter(sections: List[SectionInput]) {
     sections.zipWithIndex.foreach {
       case (section, i) =>
         if (section.mod == Modifier.Reset) {
-          val nextApp = gensym.fresh("app", "()")
-          sb.print(s"this.$nextApp\n}\ndef $nextApp: Unit = {\n")
+          val nextApp = gensym.fresh("App", "()")
+          sb.print(s"new $nextApp\n}\nclass $nextApp {\n")
         }
         sb.println("\n$doc.startSection();")
         if (section.mod == Modifier.Fail) {
@@ -97,7 +97,8 @@ object Instrumenter {
     val wrapped = new StringBuilder()
       .append("package repl\n")
       .append("class Session extends _root_.mdoc.internal.document.DocumentBuilder {\n")
-      .append("  def app(): Unit = {\n")
+      .append("  def app(): Unit = new App()\n")
+      .append("  class App {\n")
       .append(body)
       .append("  }\n")
       .append("}\n")

--- a/mdoc/src/main/scala/mdoc/internal/markdown/MarkdownCompiler.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/MarkdownCompiler.scala
@@ -7,24 +7,23 @@ import java.net.URL
 import java.net.URLClassLoader
 import java.nio.file.Path
 import java.nio.file.Paths
-import scala.meta._
-import scala.meta.inputs.Input
-import scala.meta.inputs.Position
-import scala.reflect.internal.util.AbstractFileClassLoader
-import scala.reflect.internal.util.BatchSourceFile
-import scala.tools.nsc.Global
-import scala.tools.nsc.Settings
-import scala.tools.nsc.io.AbstractFile
-import scala.tools.nsc.io.VirtualDirectory
-import scala.tools.nsc.reporters.StoreReporter
 import mdoc.Reporter
 import mdoc.document.Document
 import mdoc.document._
 import mdoc.internal.document.DocumentBuilder
 import mdoc.internal.pos.PositionSyntax
-import scala.reflect.internal.util.{Position => GPosition}
-import mdoc.internal.pos.TokenEditDistance
 import mdoc.internal.pos.PositionSyntax._
+import mdoc.internal.pos.TokenEditDistance
+import scala.meta._
+import scala.meta.inputs.Input
+import scala.meta.inputs.Position
+import scala.reflect.internal.util.AbstractFileClassLoader
+import scala.reflect.internal.util.BatchSourceFile
+import scala.reflect.internal.util.{Position => GPosition}
+import scala.tools.nsc.Global
+import scala.tools.nsc.Settings
+import scala.tools.nsc.io.AbstractFile
+import scala.tools.nsc.io.VirtualDirectory
 
 object MarkdownCompiler {
 
@@ -108,7 +107,9 @@ class MarkdownCompiler(
   settings.outputDirs.setSingleOutput(target)
   settings.classpath.value = classpath
   settings.processArgumentString(scalacOptions)
-  lazy val sreporter = new StoreReporter
+  private def _settings = settings
+
+  lazy val sreporter = new FilterStoreReporter(settings)
   private val global = new Global(settings, sreporter)
   private val appClasspath: Array[URL] = classpath
     .split(File.pathSeparator)

--- a/tests/unit/src/test/scala/tests/markdown/CrashSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/CrashSuite.scala
@@ -15,7 +15,7 @@ class CrashSuite extends BaseMarkdownSuite {
       |???
       |// scala.NotImplementedError: an implementation is missing
       |// 	at scala.Predef$.$qmark$qmark$qmark(Predef.scala:288)
-      |// 	at repl.Session.$anonfun$app$2(basic.md:13)
+      |// 	at repl.Session$App.$anonfun$new$2(basic.md:14)
       |```
     """.stripMargin
   )
@@ -62,7 +62,7 @@ class CrashSuite extends BaseMarkdownSuite {
        |  case 2 => // boom!
        |}
        |// scala.MatchError: 1 (of class java.lang.Integer)
-       |// 	at repl.Session.$anonfun$app$1(comments.md:8)
+       |// 	at repl.Session$App.$anonfun$new$1(comments.md:9)
        |```
     """.stripMargin
   )

--- a/tests/unit/src/test/scala/tests/markdown/ErrorSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/ErrorSuite.scala
@@ -16,16 +16,16 @@ class ErrorSuite extends BaseMarkdownSuite {
       |x + y + z
       |```
     """.stripMargin,
-    """
-      |error: crash.md:10:1: error: an implementation is missing
-      |x + y + z
-      |^^^^^^^^^
-      |scala.NotImplementedError: an implementation is missing
-      |	at scala.Predef$.$qmark$qmark$qmark(Predef.scala:288)
-      |	at repl.Session.crash$1(crash.md:16)
-      |	at repl.Session.z$1(crash.md:19)
-      |	at repl.Session.app(crash.md:25)
-      |""".stripMargin
+    """|error: crash.md:10:1: error: an implementation is missing
+       |x + y + z
+       |^^^^^^^^^
+       |scala.NotImplementedError: an implementation is missing
+       |	at scala.Predef$.$qmark$qmark$qmark(Predef.scala:288)
+       |	at repl.Session$App.crash(crash.md:17)
+       |	at repl.Session$App.z(crash.md:20)
+       |	at repl.Session$App.<init>(crash.md:26)
+       |	at repl.Session.app(crash.md:3)
+       |""".stripMargin
   )
 
   checkError(
@@ -90,12 +90,12 @@ class ErrorSuite extends BaseMarkdownSuite {
     """
       |```scala mdoc
       |val x = 1
-      |val x = 1
+      |val x = 2
       |```
     """.stripMargin,
-    """|error: already-defined.md:4:1: error: x is already defined as value x
-       |val x = 1
-       |^^^^^^^^^
+    """|error: already-defined.md:4:5: error: x is already defined as value x
+       |val x = 2
+       |    ^
     """.stripMargin
   )
 

--- a/tests/unit/src/test/scala/tests/markdown/SemanticsSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/SemanticsSuite.scala
@@ -1,0 +1,61 @@
+package tests.markdown
+
+class SemanticsSuite extends BaseMarkdownSuite {
+  check(
+    "overload",
+    """
+      |```scala mdoc
+      |def add(a: Int, b: Int): Int = a + b
+      |def add(a: Int): Int = add(a, 1)
+      |add(3)
+      |```
+    """.stripMargin,
+    """|```scala
+       |def add(a: Int, b: Int): Int = a + b
+       |def add(a: Int): Int = add(a, 1)
+       |add(3)
+       |// res0: Int = 4
+       |```
+    """.stripMargin
+  )
+
+  check(
+    "companion",
+    """
+      |```scala mdoc
+      |case class User(name: String)
+      |object User {
+      |  implicit val ordering: Ordering[User] = Ordering.by(_.name)
+      |}
+      |List(User("Susan"), User("John")).sorted
+      |```
+    """.stripMargin,
+    """|```scala
+       |case class User(name: String)
+       |object User {
+       |  implicit val ordering: Ordering[User] = Ordering.by(_.name)
+       |}
+       |List(User("Susan"), User("John")).sorted
+       |// res0: List[User] = List(User("John"), User("Susan"))
+       |```
+    """.stripMargin
+  )
+
+  check(
+    "mutually-recursive",
+    """
+      |```scala mdoc
+      |def isEven(n: Int): Boolean = n == 0 || !isOdd(n - 1)
+      |def isOdd(n: Int): Boolean  = n == 1 || !isEven(n - 1)
+      |isEven(8)
+      |```
+    """.stripMargin,
+    """|```scala
+       |def isEven(n: Int): Boolean = n == 0 || !isOdd(n - 1)
+       |def isOdd(n: Int): Boolean  = n == 1 || !isEven(n - 1)
+       |isEven(8)
+       |// res0: Boolean = false
+       |```
+    """.stripMargin
+  )
+}


### PR DESCRIPTION
Previously, we wrapped code inside local blocks making it impossible to
define overloaded methods. Now, the instrumented code is inside a
toplevel class lifting this restriction. This change affects mostly
stacktraces, but also error messages in some cases.